### PR TITLE
Added missing file_load()

### DIFF
--- a/modules/islandora_binary_object_zip_importer/includes/importer.inc
+++ b/modules/islandora_binary_object_zip_importer/includes/importer.inc
@@ -145,7 +145,7 @@ class BinaryObjectZipBatchImportObject extends ZipBatchImportObject {
    * @see IslandoraImportObject::getDatastreams()
    */
   protected function getDatastreams(&$errors = NULL, &$files = NULL) {
-    $to_return = parent::getDatastreams($errors, $files);
+    $to_return = array();
     $default_scheme = file_default_scheme() . "://";
     module_load_include('inc', 'islandora', 'includes/utilities');
 
@@ -185,6 +185,7 @@ class BinaryObjectZipBatchImportObject extends ZipBatchImportObject {
       $zip->open(drupal_realpath($this->source['file']->uri));
       if ($stream = $zip->getStream($name)) {
         $path = $default_scheme . basename($name);
+        file_unmanaged_save_data($stream, $path);
         $file = islandora_temp_file_entry($path, $mimetype);
         $files[] = $file;
 
@@ -208,6 +209,30 @@ class BinaryObjectZipBatchImportObject extends ZipBatchImportObject {
       $datastream['label'] = $this->getLabel($datastream['dsid'], $datastream);
     }
 
+    // See if the user uploaded DC, if not create it now.
+    if (!isset($to_return['DC'])) {
+      $obtained_dc = $this->getDC();
+      if ($obtained_dc) {
+        $name = file_create_filename('DC record.xml', 'public://');
+        file_unmanaged_save_data($obtained_dc, $name);
+        $dc_file = islandora_temp_file_entry($name, 'application/xml');
+        $files[] = $dc_file;
+        $to_return['DC'] = array(
+          'dsid' => 'DC',
+          'label' => 'DC Record',
+          'mimetype' => 'application/xml',
+          'control_group' => 'X',
+          'datastream_file' => file_create_url($dc_file->uri),
+          'file' => $dc_file,
+        );
+      }
+      else {
+        $errors[] = array(
+          t('Failed to produce DC record for @pid.'),
+        );
+      }
+    }
     return $to_return;
   }
+
 }

--- a/modules/islandora_binary_object_zip_importer/includes/importer.inc
+++ b/modules/islandora_binary_object_zip_importer/includes/importer.inc
@@ -184,9 +184,8 @@ class BinaryObjectZipBatchImportObject extends ZipBatchImportObject {
       $zip = new ZipArchive();
       $zip->open(drupal_realpath($this->source['file']->uri));
       if ($stream = $zip->getStream($name)) {
-        $path = $default_scheme . basename($name);
-        file_unmanaged_save_data($stream, $path);
-        $file = islandora_temp_file_entry($path, $mimetype);
+        $uri = file_unmanaged_save_data($stream, $default_scheme . basename($name));
+        $file = islandora_temp_file_entry($uri, $mimetype);
         $files[] = $file;
 
         $to_return += array(
@@ -213,9 +212,8 @@ class BinaryObjectZipBatchImportObject extends ZipBatchImportObject {
     if (!isset($to_return['DC'])) {
       $obtained_dc = $this->getDC();
       if ($obtained_dc) {
-        $name = file_create_filename('DC record.xml', 'public://');
-        file_unmanaged_save_data($obtained_dc, $name);
-        $dc_file = islandora_temp_file_entry($name, 'application/xml');
+        file_unmanaged_save_data($obtained_dc, 'public://DC record.xml');
+        $dc_file = islandora_temp_file_entry('public://DC record.xml', 'application/xml');
         $files[] = $dc_file;
         $to_return['DC'] = array(
           'dsid' => 'DC',

--- a/modules/islandora_binary_object_zip_importer/includes/importer.inc
+++ b/modules/islandora_binary_object_zip_importer/includes/importer.inc
@@ -79,7 +79,7 @@ class BinaryObjectZipBatchImporter extends ZipBatchImporter {
    * @see IslandoraBatchImporterInterface::getBatchInfo()
    */
   public static function getBatchInfo(array &$form_state) {
-    $file = $form_state['values']['file'];
+    $file = is_object($form_state['values']['file']) ? $form_state['values']['file'] : file_load($form_state['values']['file']);
     return array(
       'file' => $file,
       'pid_namespace' => $form_state['values']['namespace'],

--- a/modules/islandora_binary_object_zip_importer/includes/importer.inc
+++ b/modules/islandora_binary_object_zip_importer/includes/importer.inc
@@ -210,10 +210,10 @@ class BinaryObjectZipBatchImportObject extends ZipBatchImportObject {
 
     // See if the user uploaded DC, if not create it now.
     if (!isset($to_return['DC'])) {
-      $obtained_dc = $this->getDC();
+      $obtained_dc = $this->getDC($name);
       if ($obtained_dc) {
-        file_unmanaged_save_data($obtained_dc, 'public://DC record.xml');
-        $dc_file = islandora_temp_file_entry('public://DC record.xml', 'application/xml');
+        $uri = file_unmanaged_save_data($obtained_dc, $default_scheme . basename($name));
+        $dc_file = islandora_temp_file_entry($uri, 'application/xml');
         $files[] = $dc_file;
         $to_return['DC'] = array(
           'dsid' => 'DC',

--- a/modules/islandora_binary_object_zip_importer/includes/importer.inc
+++ b/modules/islandora_binary_object_zip_importer/includes/importer.inc
@@ -210,11 +210,14 @@ class BinaryObjectZipBatchImportObject extends ZipBatchImportObject {
 
     // See if the user uploaded DC, if not create it now.
     if (!isset($to_return['DC'])) {
-      $obtained_dc = $this->getDC($name);
+      $obtained_dc = $this->getDC();
       if ($obtained_dc) {
         $uri = file_unmanaged_save_data($obtained_dc, $default_scheme . basename($name));
         $dc_file = islandora_temp_file_entry($uri, 'application/xml');
         $files[] = $dc_file;
+        dsm($obtained_dc);
+        dsm($uri);
+        dsm($this->getDC());
         $to_return['DC'] = array(
           'dsid' => 'DC',
           'label' => 'DC Record',

--- a/modules/islandora_binary_object_zip_importer/includes/importer.inc
+++ b/modules/islandora_binary_object_zip_importer/includes/importer.inc
@@ -215,9 +215,6 @@ class BinaryObjectZipBatchImportObject extends ZipBatchImportObject {
         $uri = file_unmanaged_save_data($obtained_dc, $default_scheme . basename($name));
         $dc_file = islandora_temp_file_entry($uri, 'application/xml');
         $files[] = $dc_file;
-        dsm($obtained_dc);
-        dsm($uri);
-        dsm($this->getDC());
         $to_return['DC'] = array(
           'dsid' => 'DC',
           'label' => 'DC Record',


### PR DESCRIPTION
**Jira:** https://jira.duraspace.org/browse/ISLANDORA-1790
# What does this Pull Request do?

A small fix to prevent batch imports from failing upon completion. 
# How should this be tested?

This should function pretty much the same as the standard zip importer, except:
- It should not show up in the list of importers on collections that don't have the binary object content model in their policy.
- It should not allow you to select a content model.
- A Drush script version has also been created that should be tested as well.
# Additional Notes:
- Some context: https://github.com/Islandora-Labs/islandora_binary_object/pull/18
