### PR TITLE
Module respecting site ingest configs

### DIFF
--- a/includes/binary_object_upload.form.inc
+++ b/includes/binary_object_upload.form.inc
@@ -97,21 +97,21 @@ function islandora_binary_object_upload_form_submit(array $form, array &$form_st
     $file = file_load($form_state['values']['file']);
     $datastream = isset($object['OBJ']) ?
       $object['OBJ'] :
-      $datastream->constructDatastream('OBJ', 'M');
+      $datastream = $object->constructDatastream('OBJ', 'M');
 
-      $datastream->setContentFromFile($file->uri, FALSE);
+    $datastream->setContentFromFile($file->uri, FALSE);
 
-      if ($datastream->label != $file->filename) {
-        $datastream->label = $file->filename;
-      }
+    if ($datastream->label != $file->filename) {
+      $datastream->label = $file->filename;
+    }
 
-      if ($datastream->mimetype != $file->filemime) {
-        $datastream->mimetype = $file->filemime;
-      }
+    if ($datastream->mimetype != $file->filemime) {
+      $datastream->mimetype = $file->filemime;
+    }
 
-      if (!isset($object['OBJ'])) {
-        $object->ingestDatastream($datastream);
-      }
+    if (!isset($object['OBJ'])) {
+      $object->ingestDatastream($datastream);
+    }
   }
 
   if ($form_state['values']['supply_thumbnail']) {

--- a/includes/binary_object_upload.form.inc
+++ b/includes/binary_object_upload.form.inc
@@ -99,7 +99,7 @@ function islandora_binary_object_upload_form_submit(array $form, array &$form_st
   else {
     $datastream = $object['OBJ'];
   }
-  $file = file_load(isset($form_state['values']['file']));
+  $file = file_load(isset($form_state['values']['file']) ? $form_state['values']['file'] : NULL);
   $datastream->setContentFromFile($file->uri, FALSE);
   if ($datastream->label != $file->filename) {
     $datastream->label = $file->filename;

--- a/includes/binary_object_upload.form.inc
+++ b/includes/binary_object_upload.form.inc
@@ -96,14 +96,14 @@ function islandora_binary_object_upload_form_submit(array $form, array &$form_st
   if (isset($form_state['values']['file'] {
     $file = file_load($form_state['values']['file']);
     $datastream->setContentFromFile($file->uri, FALSE);
-    
+
     if ($datastream->label != $file->filename) {
       $datastream->label = $file->filename;
     }
-    
+
     if ($datastream->mimetype != $file->filemime) {
       $datastream->mimetype = $file->filemime;
-    } 
+    }
 
     if (!isset($object['OBJ'])) {
       $object->ingestDatastream($datastream);
@@ -123,11 +123,11 @@ function islandora_binary_object_upload_form_submit(array $form, array &$form_st
         $tn = $object['TN'];
       }
       $tn->setContentFromFile($thumbnail_file->uri, FALSE);
-      
+
       if ($tn->label != $thumbnail_file->filename) {
       $tn->label = $thumbnail_file->filename;
       }
-      
+
       if ($tn->mimetype != $thumbnail_file->filemime) {
         $tn->mimetype = $thumbnail_file->filemime;
       }

--- a/includes/binary_object_upload.form.inc
+++ b/includes/binary_object_upload.form.inc
@@ -93,7 +93,7 @@ function islandora_binary_object_upload_form_submit(array $form, array &$form_st
   module_load_include('inc', 'islandora', 'includes/utilities');
   $object = islandora_ingest_form_get_object($form_state);
 
-  if (isset($form_state['values']['file'] {
+  if (isset($form_state['values']['file'])) {
     $file = file_load($form_state['values']['file']);
     $datastream->setContentFromFile($file->uri, FALSE);
 
@@ -108,29 +108,29 @@ function islandora_binary_object_upload_form_submit(array $form, array &$form_st
     if (!isset($object['OBJ'])) {
       $object->ingestDatastream($datastream);
     }
+ }
 
-    if ($form_state['values']['supply_thumbnail']) {
+ if ($form_state['values']['supply_thumbnail']) 
       $thumbnail_file = file_load($form_state['values']['thumbnail_file']);
-      if ($form_state['values']['scale_thumbnail']) {
-        islandora_scale_thumbnail($thumbnail_file, 200, 200);
-      }
+    if ($form_state['values']['scale_thumbnail']) {
+      islandora_scale_thumbnail($thumbnail_file, 200, 200);
+    }
 
-      if (empty($object['TN'])) {
-        $tn = $object->constructDatastream('TN', 'M');
-        $object->ingestDatastream($tn);
-      }
-      else {
-        $tn = $object['TN'];
-      }
-      $tn->setContentFromFile($thumbnail_file->uri, FALSE);
+    if (empty($object['TN'])) {
+      $tn = $object->constructDatastream('TN', 'M');
+      $object->ingestDatastream($tn);
+    }
+    else {
+      $tn = $object['TN'];
+    }
+    $tn->setContentFromFile($thumbnail_file->uri, FALSE);
 
-      if ($tn->label != $thumbnail_file->filename) {
-      $tn->label = $thumbnail_file->filename;
-      }
+    if ($tn->label != $thumbnail_file->filename) {
+    $tn->label = $thumbnail_file->filename;
+    }
 
-      if ($tn->mimetype != $thumbnail_file->filemime) {
-        $tn->mimetype = $thumbnail_file->filemime;
-      }
+    if ($tn->mimetype != $thumbnail_file->filemime) {
+      $tn->mimetype = $thumbnail_file->filemime;
     }
   }
 }

--- a/includes/binary_object_upload.form.inc
+++ b/includes/binary_object_upload.form.inc
@@ -99,7 +99,7 @@ function islandora_binary_object_upload_form_submit(array $form, array &$form_st
   else {
     $datastream = $object['OBJ'];
   }
-  $file = file_load($form_state['values']['file']);
+  $file = file_load(isset($form_state['values']['file']));
   $datastream->setContentFromFile($file->uri, FALSE);
   if ($datastream->label != $file->filename) {
     $datastream->label = $file->filename;

--- a/includes/binary_object_upload.form.inc
+++ b/includes/binary_object_upload.form.inc
@@ -108,9 +108,9 @@ function islandora_binary_object_upload_form_submit(array $form, array &$form_st
     if (!isset($object['OBJ'])) {
       $object->ingestDatastream($datastream);
     }
- }
+  }
 
- if ($form_state['values']['supply_thumbnail']) 
+  if ($form_state['values']['supply_thumbnail'])
       $thumbnail_file = file_load($form_state['values']['thumbnail_file']);
     if ($form_state['values']['scale_thumbnail']) {
       islandora_scale_thumbnail($thumbnail_file, 200, 200);

--- a/includes/binary_object_upload.form.inc
+++ b/includes/binary_object_upload.form.inc
@@ -19,12 +19,13 @@
 function islandora_binary_object_upload_form(array $form, array &$form_state) {
   $upload_size = min((int) ini_get('post_max_size'), (int) ini_get('upload_max_filesize'));
   $thumbnail_extensions = array('gif jpg png jpeg');
+  $upload_required = variable_get('islandora_require_obj_upload', TRUE);
 
   return array(
     'file' => array(
       '#title' => t('File'),
       '#type' => 'managed_file',
-      '#required' => TRUE,
+      '#required' => $upload_required,
       '#description' => t('Select a file to upload.<br/>Files must be less than <strong>@size MB.</strong>', array('@size' => $upload_size)),
       '#default_value' => isset($form_state['values']['file']) ? $form_state['values']['file'] : NULL,
       '#upload_location' => 'temporary://',

--- a/includes/binary_object_upload.form.inc
+++ b/includes/binary_object_upload.form.inc
@@ -93,44 +93,44 @@ function islandora_binary_object_upload_form_submit(array $form, array &$form_st
   module_load_include('inc', 'islandora', 'includes/utilities');
   $object = islandora_ingest_form_get_object($form_state);
 
-  if (!isset($object['OBJ'])) {
-    $datastream = $object->constructDatastream('OBJ', 'M');
-  }
-  else {
-    $datastream = $object['OBJ'];
-  }
-  $file = file_load(isset($form_state['values']['file']) ? $form_state['values']['file'] : NULL);
-  $datastream->setContentFromFile($file->uri, FALSE);
-  if ($datastream->label != $file->filename) {
-    $datastream->label = $file->filename;
-  }
-  if ($datastream->mimetype != $file->filemime) {
-    $datastream->mimetype = $file->filemime;
-  }
+  if (isset($form_state['values']['file'] {
+    $file = file_load($form_state['values']['file']);
+    $datastream->setContentFromFile($file->uri, FALSE);
+    
+    if ($datastream->label != $file->filename) {
+      $datastream->label = $file->filename;
+    }
+    
+    if ($datastream->mimetype != $file->filemime) {
+      $datastream->mimetype = $file->filemime;
+    } 
 
-  if (!isset($object['OBJ'])) {
-    $object->ingestDatastream($datastream);
-  }
-
-  if ($form_state['values']['supply_thumbnail']) {
-    $thumbnail_file = file_load($form_state['values']['thumbnail_file']);
-    if ($form_state['values']['scale_thumbnail']) {
-      islandora_scale_thumbnail($thumbnail_file, 200, 200);
+    if (!isset($object['OBJ'])) {
+      $object->ingestDatastream($datastream);
     }
 
-    if (empty($object['TN'])) {
-      $tn = $object->constructDatastream('TN', 'M');
-      $object->ingestDatastream($tn);
-    }
-    else {
-      $tn = $object['TN'];
-    }
-    $tn->setContentFromFile($thumbnail_file->uri, FALSE);
-    if ($tn->label != $thumbnail_file->filename) {
+    if ($form_state['values']['supply_thumbnail']) {
+      $thumbnail_file = file_load($form_state['values']['thumbnail_file']);
+      if ($form_state['values']['scale_thumbnail']) {
+        islandora_scale_thumbnail($thumbnail_file, 200, 200);
+      }
+
+      if (empty($object['TN'])) {
+        $tn = $object->constructDatastream('TN', 'M');
+        $object->ingestDatastream($tn);
+      }
+      else {
+        $tn = $object['TN'];
+      }
+      $tn->setContentFromFile($thumbnail_file->uri, FALSE);
+      
+      if ($tn->label != $thumbnail_file->filename) {
       $tn->label = $thumbnail_file->filename;
-    }
-    if ($tn->mimetype != $thumbnail_file->filemime) {
-      $tn->mimetype = $thumbnail_file->filemime;
+      }
+      
+      if ($tn->mimetype != $thumbnail_file->filemime) {
+        $tn->mimetype = $thumbnail_file->filemime;
+      }
     }
   }
 }

--- a/includes/binary_object_upload.form.inc
+++ b/includes/binary_object_upload.form.inc
@@ -93,21 +93,25 @@ function islandora_binary_object_upload_form_submit(array $form, array &$form_st
   module_load_include('inc', 'islandora', 'includes/utilities');
   $object = islandora_ingest_form_get_object($form_state);
 
-  if (isset($form_state['values']['file'])) {
+  if ($form_state['values']['file']) {
     $file = file_load($form_state['values']['file']);
-    $datastream->setContentFromFile($file->uri, FALSE);
+    $datastream = isset($object['OBJ'])?
+      $object['OBJ']:
+      $datastream ->constructDatastream('OBJ', 'M');
 
-    if ($datastream->label != $file->filename) {
-      $datastream->label = $file->filename;
-    }
+      $datastream->setContentFromFile($file->uri, FALSE);
 
-    if ($datastream->mimetype != $file->filemime) {
-      $datastream->mimetype = $file->filemime;
-    }
+      if ($datastream->label != $file->filename) {
+        $datastream->label = $file->filename;
+      }
 
-    if (!isset($object['OBJ'])) {
-      $object->ingestDatastream($datastream);
-    }
+      if ($datastream->mimetype != $file->filemime) {
+        $datastream->mimetype = $file->filemime;
+      }
+
+      if (!isset($object['OBJ'])) {
+        $object->ingestDatastream($datastream);
+      }
   }
 
   if ($form_state['values']['supply_thumbnail']) {

--- a/includes/binary_object_upload.form.inc
+++ b/includes/binary_object_upload.form.inc
@@ -112,7 +112,7 @@ function islandora_binary_object_upload_form_submit(array $form, array &$form_st
 
   if ($form_state['values']['supply_thumbnail']) {
     $thumbnail_file = file_load($form_state['values']['thumbnail_file']);
-    
+
     if ($form_state['values']['scale_thumbnail']) {
       islandora_scale_thumbnail($thumbnail_file, 200, 200);
     }

--- a/includes/binary_object_upload.form.inc
+++ b/includes/binary_object_upload.form.inc
@@ -120,22 +120,22 @@ function islandora_binary_object_upload_form_submit(array $form, array &$form_st
     if ($form_state['values']['scale_thumbnail']) {
       islandora_scale_thumbnail($thumbnail_file, 200, 200);
     }
-  }
 
-  if (empty($object['TN'])) {
-    $tn = $object->constructDatastream('TN', 'M');
-    $object->ingestDatastream($tn);
-  }
-  else {
-    $tn = $object['TN'];
-  }
-  $tn->setContentFromFile($thumbnail_file->uri, FALSE);
+    if (empty($object['TN'])) {
+      $tn = $object->constructDatastream('TN', 'M');
+      $object->ingestDatastream($tn);
+    }
+    else {
+      $tn = $object['TN'];
+    }
+    $tn->setContentFromFile($thumbnail_file->uri, FALSE);
 
-  if ($tn->label != $thumbnail_file->filename) {
-    $tn->label = $thumbnail_file->filename;
-  }
+    if ($tn->label != $thumbnail_file->filename) {
+      $tn->label = $thumbnail_file->filename;
+    }
 
-  if ($tn->mimetype != $thumbnail_file->filemime) {
-    $tn->mimetype = $thumbnail_file->filemime;
+    if ($tn->mimetype != $thumbnail_file->filemime) {
+      $tn->mimetype = $thumbnail_file->filemime;
+    }
   }
 }

--- a/includes/binary_object_upload.form.inc
+++ b/includes/binary_object_upload.form.inc
@@ -95,9 +95,9 @@ function islandora_binary_object_upload_form_submit(array $form, array &$form_st
 
   if ($form_state['values']['file']) {
     $file = file_load($form_state['values']['file']);
-    $datastream = isset($object['OBJ'])?
-      $object['OBJ']:
-      $datastream ->constructDatastream('OBJ', 'M');
+    $datastream = isset($object['OBJ']) ?
+      $object['OBJ'] :
+      $datastream->constructDatastream('OBJ', 'M');
 
       $datastream->setContentFromFile($file->uri, FALSE);
 

--- a/includes/binary_object_upload.form.inc
+++ b/includes/binary_object_upload.form.inc
@@ -127,7 +127,7 @@ function islandora_binary_object_upload_form_submit(array $form, array &$form_st
     $tn->setContentFromFile($thumbnail_file->uri, FALSE);
 
     if ($tn->label != $thumbnail_file->filename) {
-    $tn->label = $thumbnail_file->filename;
+      $tn->label = $thumbnail_file->filename;
     }
 
     if ($tn->mimetype != $thumbnail_file->filemime) {

--- a/includes/binary_object_upload.form.inc
+++ b/includes/binary_object_upload.form.inc
@@ -120,22 +120,22 @@ function islandora_binary_object_upload_form_submit(array $form, array &$form_st
     if ($form_state['values']['scale_thumbnail']) {
       islandora_scale_thumbnail($thumbnail_file, 200, 200);
     }
+  }
 
-    if (empty($object['TN'])) {
-      $tn = $object->constructDatastream('TN', 'M');
-      $object->ingestDatastream($tn);
-    }
-    else {
-      $tn = $object['TN'];
-    }
-    $tn->setContentFromFile($thumbnail_file->uri, FALSE);
+  if (empty($object['TN'])) {
+    $tn = $object->constructDatastream('TN', 'M');
+    $object->ingestDatastream($tn);
+  }
+  else {
+    $tn = $object['TN'];
+  }
+  $tn->setContentFromFile($thumbnail_file->uri, FALSE);
 
-    if ($tn->label != $thumbnail_file->filename) {
-      $tn->label = $thumbnail_file->filename;
-    }
+  if ($tn->label != $thumbnail_file->filename) {
+    $tn->label = $thumbnail_file->filename;
+  }
 
-    if ($tn->mimetype != $thumbnail_file->filemime) {
-      $tn->mimetype = $thumbnail_file->filemime;
-    }
+  if ($tn->mimetype != $thumbnail_file->filemime) {
+    $tn->mimetype = $thumbnail_file->filemime;
   }
 }

--- a/includes/binary_object_upload.form.inc
+++ b/includes/binary_object_upload.form.inc
@@ -19,13 +19,12 @@
 function islandora_binary_object_upload_form(array $form, array &$form_state) {
   $upload_size = min((int) ini_get('post_max_size'), (int) ini_get('upload_max_filesize'));
   $thumbnail_extensions = array('gif jpg png jpeg');
-  $upload_required = variable_get('islandora_require_obj_upload', TRUE);
 
   return array(
     'file' => array(
       '#title' => t('File'),
       '#type' => 'managed_file',
-      '#required' => $upload_required,
+      '#required' => variable_get('islandora_require_obj_upload', TRUE),
       '#description' => t('Select a file to upload.<br/>Files must be less than <strong>@size MB.</strong>', array('@size' => $upload_size)),
       '#default_value' => isset($form_state['values']['file']) ? $form_state['values']['file'] : NULL,
       '#upload_location' => 'temporary://',

--- a/includes/binary_object_upload.form.inc
+++ b/includes/binary_object_upload.form.inc
@@ -110,8 +110,9 @@ function islandora_binary_object_upload_form_submit(array $form, array &$form_st
     }
   }
 
-  if ($form_state['values']['supply_thumbnail'])
-      $thumbnail_file = file_load($form_state['values']['thumbnail_file']);
+  if ($form_state['values']['supply_thumbnail']) {
+    $thumbnail_file = file_load($form_state['values']['thumbnail_file']);
+    
     if ($form_state['values']['scale_thumbnail']) {
       islandora_scale_thumbnail($thumbnail_file, 200, 200);
     }

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -33,7 +33,7 @@ function islandora_binary_object_create_thumbnail(AbstractObject $object, $force
       }
       // Go see if we have an association that exists for this MIME type and
       // if we do use that. If not default back to the generic image.
-      if (islandora_binary_object_check_mime_type($object['OBJ']->mimetype)) {
+      if (isset($object['OBJ']) && islandora_binary_object_check_mime_type($object['OBJ']->mimetype)) {
         $fid_to_load = islandora_binary_object_retrieve_file_id_by_association($object['OBJ']->mimetype);
         $file = file_load($fid_to_load);
         $ds->mimetype = $file->filemime;

--- a/islandora_binary_object.module
+++ b/islandora_binary_object.module
@@ -157,7 +157,7 @@ function islandora_binary_object_islandora_binaryObjectCModel_islandora_view_obj
 function islandora_binary_object_islandora_binaryObjectCModel_islandora_derivative() {
   return array(
     array(
-      'source_dsid' => 'OBJ',
+      'source_dsid' => NULL,
       'destination_dsid' => 'TN',
       'weight' => '0',
       'function' => array(


### PR DESCRIPTION
**JIRA Ticket**: (link)

# What does this Pull Request do?

This pull request ensures that when a binary object is ingested, it respects the site configurations regarding file upload requirements.  

# What's new?

Uses the function variable_get() to find the site configurations about objects requiring uploads. 

# How should this be tested?

Go to /admin/islandora/tools/binary-object-storage and try to ingest a binary object without uploading anything. 
