### PR TITLE
Viewers

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -19,7 +19,7 @@
 function islandora_binary_object_admin(array $form, array &$form_state) {
   module_load_include('inc', 'islandora', 'includes/utilities');
   module_load_include('inc', 'islandora', 'includes/solution_packs');
-  
+
   $form += islandora_viewers_form('islandora_binary_csv_viewers', 'text/csv');
   $form['csv_viewers'] = $form['viewers'];
   $form['csv_viewers']['#title'] = t('CSV Viewers');
@@ -29,7 +29,6 @@ function islandora_binary_object_admin(array $form, array &$form_state) {
   $form['zip_viewers']['#title'] = t('ZIP Viewers');
   unset($form['viewers']);
 
-  
   return system_settings_form($form);
 }
- 
+

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -31,4 +31,3 @@ function islandora_binary_object_admin(array $form, array &$form_state) {
 
   return system_settings_form($form);
 }
-

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @file
+ * Handles the display/submission of the admin settings form for this module.
+ */
+
+/**
+ * Defines the admin settings form.
+ *
+ * @param array $form
+ *   The Drupal form definition.
+ * @param array $form_state
+ *   The Drupal form state.
+ *
+ * @return array
+ *   The Drupal form definition.
+ */
+function islandora_binary_object_admin(array $form, array &$form_state) {
+  module_load_include('inc', 'islandora', 'includes/utilities');
+  module_load_include('inc', 'islandora', 'includes/solution_packs');
+  
+  $form += islandora_viewers_form('islandora_binary_csv_viewers', 'text/csv');
+  $form['csv_viewers'] = $form['viewers'];
+  $form['csv_viewers']['#title'] = t('CSV Viewers');
+  unset($form['viewers']);
+  $form += islandora_viewers_form('islandora_binary_zip_viewers', 'application/zip');
+  $form['zip_viewers'] = $form['viewers'];
+  $form['zip_viewers']['#title'] = t('ZIP Viewers');
+  unset($form['viewers']);
+
+  
+  return system_settings_form($form);
+}
+ 

--- a/includes/viewer.inc
+++ b/includes/viewer.inc
@@ -3,6 +3,7 @@
 function islandora_binary_object_get_viewer($object, $mimetype) {
   module_load_include('inc', 'islandora', 'islandora');
   module_load_include('inc', 'islandora', 'includes/solution_packs');
+
   if ($mimetype == 'text/csv') {
     $params = array();
     $params['url'] = url("islandora/object/{$object->id}/datastream/OBJ/view", array('absolute' => TRUE));
@@ -11,6 +12,8 @@ function islandora_binary_object_get_viewer($object, $mimetype) {
   }
   if ($mimetype == 'application/zip') {
     $params = array();
+    $params['url'] = url("islandora/object/{$object->id}/datastream/OBJ/view", array('absolute' => TRUE));
+
     return islandora_get_viewer($params, 'islandora_binary_zip_viewers', $object);
   }
   return null;

--- a/includes/viewer.inc
+++ b/includes/viewer.inc
@@ -12,7 +12,7 @@ function islandora_binary_object_get_viewer($object, $mimetype) {
   }
   if ($mimetype == 'application/zip') {
     $params = array();
-    $params['url'] = url("islandora/object/{$object->id}/datastream/OBJ/view", array('absolute' => TRUE));
+    $params['dsid'] = 'OBJ';
 
     return islandora_get_viewer($params, 'islandora_binary_zip_viewers', $object);
   }

--- a/includes/viewer.inc
+++ b/includes/viewer.inc
@@ -1,6 +1,23 @@
 <?php
 
-function islandora_binary_object_get_viewer($object, $mimetype) {
+/**
+ * @file
+ * Holds the viewer callbacks.
+ */
+
+
+/**
+ * Selects and calls viewers
+ *
+ * @param AbstractObject $object
+ *   The object the viewer will display
+ * @param string $mimetype
+ *   The Drupal form state
+ *
+ * @return string
+ *   The callback to the viewer module. Returns a rendered viewer.
+ */
+function islandora_binary_object_get_viewer(AbstractObject $object, $mimetype) {
   module_load_include('inc', 'islandora', 'islandora');
   module_load_include('inc', 'islandora', 'includes/solution_packs');
 
@@ -18,3 +35,4 @@ function islandora_binary_object_get_viewer($object, $mimetype) {
   }
   return null;
 }
+

--- a/includes/viewer.inc
+++ b/includes/viewer.inc
@@ -1,0 +1,15 @@
+<?php
+
+function islandora_binary_object_get_viewer($object, $mimetype) {
+  module_load_include('inc', 'islandora', 'islandora');
+  module_load_include('inc', 'islandora', 'includes/solution_packs');
+  if ($mimetype == 'text/csv') {
+    $params = array();
+    return islandora_get_viewer($params, 'islandora_binary_csv_viewers', $object);
+  }
+  if ($mimetype == 'application/zip') {
+    $params = array();
+    return islandora_get_viewer($params, 'islandora_binary_zip_viewers', $object);
+  }
+  return null;
+}

--- a/includes/viewer.inc
+++ b/includes/viewer.inc
@@ -32,5 +32,5 @@ function islandora_binary_object_get_viewer(AbstractObject $object, $mimetype) {
 
     return islandora_get_viewer($params, 'islandora_binary_zip_viewers', $object);
   }
-  return null;
+  return NULL;
 }

--- a/includes/viewer.inc
+++ b/includes/viewer.inc
@@ -5,7 +5,6 @@
  * Holds the viewer callbacks.
  */
 
-
 /**
  * Selects and calls viewers
  *

--- a/includes/viewer.inc
+++ b/includes/viewer.inc
@@ -6,7 +6,7 @@
  */
 
 /**
- * Selects and calls viewers
+ * Selects and calls viewers.
  *
  * @param AbstractObject $object
  *   The object the viewer will display
@@ -34,4 +34,3 @@ function islandora_binary_object_get_viewer(AbstractObject $object, $mimetype) {
   }
   return null;
 }
-

--- a/includes/viewer.inc
+++ b/includes/viewer.inc
@@ -5,6 +5,8 @@ function islandora_binary_object_get_viewer($object, $mimetype) {
   module_load_include('inc', 'islandora', 'includes/solution_packs');
   if ($mimetype == 'text/csv') {
     $params = array();
+    $params['url'] = url("islandora/object/{$object->id}/datastream/OBJ/view", array('absolute' => TRUE));
+
     return islandora_get_viewer($params, 'islandora_binary_csv_viewers', $object);
   }
   if ($mimetype == 'application/zip') {

--- a/islandora_binary_object.module
+++ b/islandora_binary_object.module
@@ -30,15 +30,14 @@ function islandora_binary_object_menu() {
     'file' => 'includes/admin.inc',
   );
   $items['admin/islandora/solution_pack_config/binary_object_collection'] = array(
-      'title' => 'Binary Solution Pack',
-      'description' => 'Configure viewers for binary objects.',
-      'page callback' => 'drupal_get_form',
-      'access arguments' => array('administer site configuration'),
-      'page arguments' => array('islandora_binary_object_admin'),
-      'file' => 'includes/admin.form.inc',
-      'type' => MENU_NORMAL_ITEM,
-    );
-
+    'title' => 'Binary Solution Pack',
+    'description' => 'Configure viewers for binary objects.',
+    'page callback' => 'drupal_get_form',
+    'access arguments' => array('administer site configuration'),
+    'page arguments' => array('islandora_binary_object_admin'),
+    'file' => 'includes/admin.form.inc',
+    'type' => MENU_NORMAL_ITEM,
+  );
   return $items;
 }
 /**

--- a/islandora_binary_object.module
+++ b/islandora_binary_object.module
@@ -29,6 +29,16 @@ function islandora_binary_object_menu() {
     ),
     'file' => 'includes/admin.inc',
   );
+  $items['admin/islandora/solution_pack_config/binary_object_collection'] = array(
+      'title' => 'Binary Solution Pack',
+      'description' => 'Configure viewers for binary objects.',
+      'page callback' => 'drupal_get_form',
+      'access arguments' => array('administer site configuration'),
+      'page arguments' => array('islandora_binary_object_admin'),
+      'file' => 'includes/admin.form.inc',
+      'type' => MENU_NORMAL_ITEM,
+    );
+
   return $items;
 }
 /**

--- a/theme/islandora-binary-object.tpl.php
+++ b/theme/islandora-binary-object.tpl.php
@@ -23,7 +23,11 @@
     <?php if (isset($islandora_binary_object_info)): ?>
       <?php print $islandora_binary_object_info; ?>
     <?php endif; ?>
-    <?php if (isset($islandora_thumbnail_img)): ?>
+    <?php if (isset($islandora_viewer)): ?>
+      <div class="islandora-binary-object-viewer">
+        <?php print $islandora_viewer; ?>
+      </div>
+    <?php elseif (isset($islandora_thumbnail_img)): ?>
       <div class="islandora-binary-object-content">
         <?php print $islandora_thumbnail_img; ?>
       </div>

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -9,6 +9,7 @@
  */
 function template_preprocess_islandora_binary_object(array &$variables) {
   module_load_include('inc', 'islandora', 'includes/metadata');
+  module_load_include('inc', 'islandora_binary_object', 'includes/viewer');
   drupal_add_js('misc/form.js');
   drupal_add_js('misc/collapse.js');
 
@@ -29,8 +30,13 @@ function template_preprocess_islandora_binary_object(array &$variables) {
       '#markup' => l(t('@label', array('@label' => $islandora_object['OBJ']->label)), "islandora/object/$islandora_object->id/datastream/OBJ/download"),
     );
     $variables['islandora_binary_object_download'] = drupal_render($display['download']);
+    
+    //viewer
+    $viewer = islandora_binary_object_get_viewer($islandora_object, $islandora_object['OBJ']->mimetype);
+    if($viewer != null)
+      $variables['islandora_viewer'] = $viewer;
   }
-
+  
   // Thumbnail.
   if (isset($islandora_object['TN']) && islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $islandora_object['TN'])) {
     $thumbnail_size_url = url("islandora/object/{$islandora_object->id}/datastream/TN/view");

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -30,13 +30,13 @@ function template_preprocess_islandora_binary_object(array &$variables) {
       '#markup' => l(t('@label', array('@label' => $islandora_object['OBJ']->label)), "islandora/object/$islandora_object->id/datastream/OBJ/download"),
     );
     $variables['islandora_binary_object_download'] = drupal_render($display['download']);
-    
-    //viewer
+
+    // Viewer.
     $viewer = islandora_binary_object_get_viewer($islandora_object, $islandora_object['OBJ']->mimetype);
     if($viewer != null)
       $variables['islandora_viewer'] = $viewer;
   }
-  
+
   // Thumbnail.
   if (isset($islandora_object['TN']) && islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $islandora_object['TN'])) {
     $thumbnail_size_url = url("islandora/object/{$islandora_object->id}/datastream/TN/view");

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -33,8 +33,9 @@ function template_preprocess_islandora_binary_object(array &$variables) {
 
     // Viewer.
     $viewer = islandora_binary_object_get_viewer($islandora_object, $islandora_object['OBJ']->mimetype);
-    if($viewer != null)
+    if ($viewer != null) {
       $variables['islandora_viewer'] = $viewer;
+    }
   }
 
   // Thumbnail.

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -33,7 +33,7 @@ function template_preprocess_islandora_binary_object(array &$variables) {
 
     // Viewer.
     $viewer = islandora_binary_object_get_viewer($islandora_object, $islandora_object['OBJ']->mimetype);
-    if ($viewer != null) {
+    if ($viewer != NULL) {
       $variables['islandora_viewer'] = $viewer;
     }
   }


### PR DESCRIPTION
# What does this Pull Request do?

Adds in hooks to object viewers.

# What's new?
For binary objects where the mime-type of 'OBJ' is either 'text/csv' or 'application/zip', a viewer can be set to be displayed instead of the thumbnail.

# How should this be tested?
Objects matching the above mime-types should be ingested into the database. In addition, these viewer modules or another for the same mime-type are required.
* [csv](https://github.com/matt474/islandora_reclinejs)
* [zip](https://github.com/matt474/islandora_jstree)