### PR TITLE
Fix form error when using with plupload

### DIFF
--- a/includes/binary_object_upload.form.inc
+++ b/includes/binary_object_upload.form.inc
@@ -30,7 +30,7 @@ function islandora_binary_object_upload_form(array $form, array &$form_state) {
       '#upload_location' => 'temporary://',
       '#upload_validators' => array(
         // Assume its specified in MB.
-        'file_validate_extensions' => array(),
+        'file_validate_extensions' => array(NULL),
         'file_validate_size' => array($upload_size * 1024 * 1024),
       ),
     ),


### PR DESCRIPTION
**JIRA Ticket**: (waiting for Jira access to create the ticket).

# What does this Pull Request do?

Drupal's `theme_file_upload_help` only checks for the existence of
the 'file_validate_extensions' key then tries to get the
first element, so it was throwing an undefined offset error
with an empty array. This PR fixes that bug.

# What's new

Sets the upload validators' `file_validate_extensions` array to `array(NULL)` instead of empty array.

# How should this be tested?

Create test collection
Set policy to allow binary cModel
Add object, select binary cModel
Enter object title in form presented
Click Next
Verify no error thrown
