### PR TITLE
Update travis.yml to force PHP 5.3.3 to run on precise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,20 @@
+sudo: required
+dist: trusty
 language: php
+
+matrix:
+  include:
+    #5.3.3 Ubuntu Precise exceptions
+    - php: 5.3.3
+      dist: precise
+      env: FEDORA_VERSION="3.5"
+    - php: 5.3.3
+      dist: precise
+      env: FEDORA_VERSION="3.6.2"
+    - php: 5.3.3
+      dist: precise
+      env: FEDORA_VERSION="3.7.0"
 php:
-  - 5.3.3
   - 5.4
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,15 @@ matrix:
     - php: 5.3.3
       dist: precise
       env: FEDORA_VERSION="3.7.0"
+    - php: 5.3.3
+      dist: precise
+      env: FEDORA_VERSION="3.8.1"
 php:
   - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
+  - 7.1
 branches:
   only:
     - 7.x
@@ -23,6 +30,7 @@ env:
   - FEDORA_VERSION="3.5"
   - FEDORA_VERSION="3.6.2"
   - FEDORA_VERSION="3.7.0"
+  - FEDORA_VERSION="3.8.1"
 before_install:
   - cd $HOME
   - git clone -b 7.x git://github.com/Islandora/islandora.git


### PR DESCRIPTION
**JIRA Ticket**: need to merge this before the [ISLANDORA-2310](https://jira.duraspace.org/browse/ISLANDORA-2310) PR can pass.

# What does this Pull Request do?

Fixes travis configuration to make PHP 5.3 builds pass; forces travis to run PHP 5.3.3 builds on Ubuntu Precise.

# What's new?

Moved PHP 5.3.3 and corresponding fedora versions to the matrix section of the travis YAML file.

# How should this be tested?

Travis CI should pass and every PHP/Fedora version combination should be green
