### PR TITLE
ISLANDORA-2310: Fix 'undefined offset' error when using plupload

### DIFF
--- a/includes/binary_object_upload.form.inc
+++ b/includes/binary_object_upload.form.inc
@@ -30,7 +30,7 @@ function islandora_binary_object_upload_form(array $form, array &$form_state) {
       '#upload_location' => 'temporary://',
       '#upload_validators' => array(
         // Assume its specified in MB.
-        'file_validate_extensions' => array(),
+        'file_validate_extensions' => array(NULL),
         'file_validate_size' => array($upload_size * 1024 * 1024),
       ),
     ),


### PR DESCRIPTION


**JIRA Ticket**: [ISLANDORA-2310](https://jira.duraspace.org/browse/ISLANDORA-2310)

# What does this Pull Request do?

Drupal's `theme_file_upload_help` only checks for the existence of the `file_validate_extension` key then tries to get the first element, so it was throwing an undefined offset error due to the empty array being defined here and passed to drupal via plupload.

# What's new?
Adds a `NULL` element to the array so that drupal does not complain about an empty array.

# How should this be tested?
Dependencies:
See [islandora_plupload.info](https://github.com/discoverygarden/islandora_plupload/blob/7.x/islandora_plupload.info)

Steps to reproduce:
Enable plupload
Create test collection
Set policy to allow binary cModel
Add object, select binary cModel
Go to file upload page
Verify error thrown: `Undefined offset: 0 in theme_file_upload_help() (line 953 of /var/www/drupal7/modules/file/file.field.inc)`

# Additional Notes:
This replaces #30, which had not been made from a feature branch.

Note that travis build will fail until #31 is merged.